### PR TITLE
Removed superfluous func declarations, renamed printList

### DIFF
--- a/gcov.c
+++ b/gcov.c
@@ -723,7 +723,7 @@ output_intermediate_file (FILE *gcov_file, source_t *src)
 
     addToList(&list, "branch", &branch, "list");
     addToList(&list, "lc", &lc, "list");
-    printList(&list, gcov_file);
+    printAndDeleteList(&list, gcov_file);
 }
 
 

--- a/list.c
+++ b/list.c
@@ -145,7 +145,7 @@ static void printAndDeleteNode (struct Node *node, FILE *file) {
 
 /* Print elements in a list as a JSON object.
  */
-void printList (struct List *list, FILE *file) {
+void printAndDeleteList (struct List *list, FILE *file) {
     fprintf(file, "\n{");
     printAndDeleteNode(list->front, file);
     fprintf(file, "}\n");

--- a/list.h
+++ b/list.h
@@ -13,11 +13,9 @@ struct List {
     struct Node *back;
 };
 
-void deleteList(struct List *);
 void initList(struct List *);
 int isEmptyList(struct List *);
 void addToList(struct List *, const char *, const void *, 
                const char *);
-void deleteList(struct List *);
-void printList(struct List *, FILE *);
+void printAndDeleteList(struct List *, FILE *);
 #endif


### PR DESCRIPTION
printList is now called printAndDeleteList for clarity.
list.h no longer has declarations of deleteList.
